### PR TITLE
Feature/Add type date parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,7 @@ The types of the *request_type* can be:
 - string *(default)*
 - bool
 - array
+- date
 
 
 ### Examples

--- a/src/Service/ExternalParametersService.php
+++ b/src/Service/ExternalParametersService.php
@@ -95,7 +95,9 @@ class ExternalParametersService
                     $arrayFilters[$k]['value'] = array_filter((array)$request->get($filter['request_name']), function ($value) {
                         return !empty($value);
                     });
-
+                    break;
+                case 'date':
+                    $arrayFilters[$k]['value'] = new \DateTime($request->get($filter['request_name']));
                     break;
                 default:
                     $arrayFilters[$k]['value'] = trim((string)$request->get($filter['request_name']));


### PR DESCRIPTION
There was four different types of 'request_type' parameter: 
- int
- bool
- array
- string

So, now, a new one has been added:
- date

It will return a Datetime with the value of the param